### PR TITLE
feat: add active route highlighting to header navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@vercel/analytics": "^1.5.0",
+        "clsx": "^2.1.1",
         "lucide-react": "^0.575.0",
         "next": "^14.2.33",
         "react": "^18",
@@ -4009,6 +4010,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^1.5.0",
+    "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
     "next": "^14.2.33",
     "react": "^18",

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import { useMobileMenu } from '@/hooks/use-mobile-menu';
+import clsx from 'clsx';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 export function Header() {
+  const pathname = usePathname();
   const { isMenuOpen, toggleMenu, closeMenu } = useMobileMenu();
 
   function handleWhatsAppClick() {
@@ -23,16 +26,22 @@ export function Header() {
           {isMenuOpen && (
             <nav className="fixed inset-0 bg-cream/90 backdrop-blur-md border-b flex flex-col items-center justify-center gap-8 md:hidden h-screen w-screen z-40">
               <Link
+                className={clsx(
+                  'text-slate-700 hover:text-primary transition-colors text-sm font-bold uppercase tracking-widest',
+                  pathname === '/' ? 'border-b-2 border-muted-orange' : ''
+                )}
                 href="/"
                 onClick={closeMenu}
-                className="text-2xl font-bold hover:text-foreground/80 transition-colors"
               >
                 Home
               </Link>
               <Link
+                className={clsx(
+                  'text-slate-700 hover:text-primary transition-colors text-sm font-bold uppercase tracking-widest',
+                  pathname === '/agenda' ? 'border-b-2 border-muted-orange' : ''
+                )}
                 href="/agenda"
                 onClick={closeMenu}
-                className="text-2xl font-bold hover:text-foreground/80 transition-colors"
               >
                 Agenda
               </Link>
@@ -94,16 +103,23 @@ export function Header() {
             )}
           </button>
         </div>
+
         <div className="flex flex-row gap-10">
           <nav className="hidden md:flex items-center gap-10">
             <Link
-              className="text-slate-700 hover:text-primary transition-colors text-sm font-bold uppercase tracking-widest"
+              className={clsx(
+                'text-slate-700 hover:text-primary transition-colors text-sm font-bold uppercase tracking-widest',
+                pathname === '/' ? 'border-b-2 border-muted-orange' : ''
+              )}
               href="/"
             >
               Home
             </Link>
             <Link
-              className="text-slate-700 hover:text-primary transition-colors text-sm font-bold uppercase tracking-widest"
+              className={clsx(
+                'text-slate-700 hover:text-primary transition-colors text-sm font-bold uppercase tracking-widest',
+                pathname === '/agenda' ? 'border-b-2 border-muted-orange' : ''
+              )}
               href="/agenda"
             >
               Agenda


### PR DESCRIPTION
:loudspeaker: **O que está sendo feito?**
- Add destaque no link da pagina ativa

:bulb: **Como isso está sendo feito?**
- Destaque de rota ativa: Implementado destaque visual para o link da página ativa na navegação do cabeçalho, tanto para visualizações mobile quanto desktop.
- Adição de dependências: Adicionada a biblioteca 'clsx' para facilitar a construção condicional de classes CSS.
- Lógica de roteamento: Utilizado o hook 'usePathname' do Next.js para determinar a rota atual e aplicar estilos dinamicamente.

